### PR TITLE
in README instructions, build release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you have issues running the compiled binary (`permission denied` error), try 
 #### Compiling and installing
 ```
 swift package update
-swift build
+swift build -c release
 mv .build/release/BluetoothConnector /usr/local/bin/BluetoothConnector
 ```
 


### PR DESCRIPTION
Otherwise the next step fails because the default is to build a debug binary and it's in .build/debug/ instead of .build/release/