### PR TITLE
Pin swift-argument-parser package version to 0.0.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-	   .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.0.1")
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("0.0.2"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
When I was trying to compile locally, I ran into build issues from the swift-argument-parser package - it appears as the API of it has changed. This PR pins the dependency to the exact version specified in the `Package.resolved` file.

FWIW - I've never written swift before so I don't know if this is the actual correct solution for handling dependency versions. Apologies if this is far off base and a waste of time! Hopefully though if anyone else is trying to compile locally this can point them in the right direction.

---

Mostly to add for searchability - this was the original error I ran into when running `swift package update && swift build -c release`


```
$ swift build -c release
/Users/nathan/dev/BluetoothConnector/Sources/BluetoothConnector/main.swift:120:6: error: referencing initializer 'init(name:help:)' on 'Flag' requires the types 'Bool' and 'Int' be equivalent
    @Flag(name: .shortAndLong, help: "Connect a device")
     ^
/Users/nathan/dev/BluetoothConnector/.build/checkouts/swift-argument-parser/Sources/ArgumentParser/Parsable Properties/Flag.swift:298:1: note: where 'Value' = 'Bool'
extension Flag where Value == Int {
^
/Users/nathan/dev/BluetoothConnector/Sources/BluetoothConnector/main.swift:123:6: error: referencing initializer 'init(name:help:)' on 'Flag' requires the types 'Bool' and 'Int' be equivalent
    @Flag(name: .shortAndLong, help: "Disconnect a device")
     ^
/Users/nathan/dev/BluetoothConnector/.build/checkouts/swift-argument-parser/Sources/ArgumentParser/Parsable Properties/Flag.swift:298:1: note: where 'Value' = 'Bool'
extension Flag where Value == Int {
^
/Users/nathan/dev/BluetoothConnector/Sources/BluetoothConnector/main.swift:126:6: error: referencing initializer 'init(name:help:)' on 'Flag' requires the types 'Bool' and 'Int' be equivalent
    @Flag(name: .shortAndLong, help: "Get the status of a device")
     ^
/Users/nathan/dev/BluetoothConnector/.build/checkouts/swift-argument-parser/Sources/ArgumentParser/Parsable Properties/Flag.swift:298:1: note: where 'Value' = 'Bool'
extension Flag where Value == Int {
^
/Users/nathan/dev/BluetoothConnector/Sources/BluetoothConnector/main.swift:129:6: error: referencing initializer 'init(name:help:)' on 'Flag' requires the types 'Bool' and 'Int' be equivalent
    @Flag(name: .shortAndLong, help: "Post a Notification Center notification")
     ^
/Users/nathan/dev/BluetoothConnector/.build/checkouts/swift-argument-parser/Sources/ArgumentParser/Parsable Properties/Flag.swift:298:1: note: where 'Value' = 'Bool'
extension Flag where Value == Int {
^
/Users/nathan/dev/BluetoothConnector/Sources/BluetoothConnector/main.swift:121:9: note: cannot automatically synthesize 'Decodable' because '<<error type>>' does not conform to 'Decodable'
    var connect: Bool
        ^
/Users/nathan/dev/BluetoothConnector/Sources/BluetoothConnector/main.swift:124:9: note: cannot automatically synthesize 'Decodable' because '<<error type>>' does not conform to 'Decodable'
    var disconnect: Bool
        ^
/Users/nathan/dev/BluetoothConnector/Sources/BluetoothConnector/main.swift:127:9: note: cannot automatically synthesize 'Decodable' because '<<error type>>' does not conform to 'Decodable'
    var status: Bool
        ^
/Users/nathan/dev/BluetoothConnector/Sources/BluetoothConnector/main.swift:130:9: note: cannot automatically synthesize 'Decodable' because '<<error type>>' does not conform to 'Decodable'
    var notify: Bool
        ^
/Users/nathan/dev/BluetoothConnector/Sources/BluetoothConnector/main.swift:119:8: error: type 'BluetoothConnector' does not conform to protocol 'Decodable'
struct BluetoothConnector: ParsableCommand {
       ^
Swift.Decodable:2:5: note: protocol requires initializer 'init(from:)' with type 'Decodable'
    init(from decoder: Decoder) throws
    ^

```